### PR TITLE
Fix variable file parsing.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure("2") do |config|
     sudo ln -s /vagrant/vagrant/etc/kitbash/models.d .
     sudo ln -s /vagrant/vagrant/etc/kitbash/local .
     sudo ln -s /vagrant/vagrant/etc/kitbash/variables .
+    sudo ln -s /vagrant/bin/babashka /usr/bin/kitbash
     SHELL
     v.vm.provision "shell", run: :once, name: :mise, path: "vagrant/scripts/02-mise.sh" 
   end

--- a/dependencies/service/systemd/system.sh
+++ b/dependencies/service/systemd/system.sh
@@ -52,7 +52,7 @@ system.service.start.systemd() {
   shift
   emit "$_unit"
   get_id() {
-    printf "%s" "$_unit"
+    printf "%s\n" "$_unit"
   }
   is_met() {
     systemctl is-active "$_unit" | grep -q "active"

--- a/helpers/01-core.sh
+++ b/helpers/01-core.sh
@@ -1,5 +1,8 @@
 ## Provides some core functionality for use in Babashka
 
+### Globals
+__STR_CASEFOLD_LOCALE=""
+
 bb.core.element_in_array() {
   # search for thing in array, which will now be "$@"
   # Exists to make Bash a bit more other languages
@@ -20,6 +23,13 @@ in_array() {
 types.array.exists() {
   if ! declare -p "$1" | grep -q 'declare -a'; then
     log.error "Undefined array '$1'."
+    return 1
+  fi
+}
+
+types.hash.exists() {
+  if ! declare -p "$1" | grep -q 'declare -A'; then
+    log.error "Undefined associative array '$1'."
     return 1
   fi
 }
@@ -153,11 +163,11 @@ types.assoc.copy() {
   src_name="$1"
   dst_name="$2"
   if ! declare -p "$src_name" 2>/dev/null | grep -q 'declare -A'; then
-    log.error "No such source '$src'"
+    emit error "No such source '$src'"
     return 1
   fi
   if ! declare -p "$dst_name" 2>/dev/null | grep -q 'declare -A'; then
-    log.error "No such destination '$dst'"
+    emit error "No such destination '$dst'"
     return 2
   fi
   local -n src
@@ -169,18 +179,26 @@ types.assoc.copy() {
   done
 }
 
+str.dot_to_underscore() {
+  local str
+  str="$*"
+  str="$(str.normalize "$str")"
+  str="$(str.casefold "$str")"
+  printf '%s\n' "${str//./_}"
+}
+
 ##
 ## string helpers
 ##
 
 kitbash.str.normalise() {
-  local raw="$1"
+  local raw value
+  raw="$*"
   # Collapse all whitespace to single spaces
-  local value
   value="$(printf '%s' "$raw" | tr -s '[:space:]' ' ')"
   value="${value#"${value%%[![:space:]]*}"}" # Trim leading whitespace
   value="${value%"${value##*[![:space:]]}"}" # ... and trailing
-  echo "$value"
+  printf '%s\n' "$value"
 }
 
 bb.core.normalise_string() {
@@ -195,11 +213,15 @@ normalize() {
   kitbash.str.normalise "$@"
 }
 
+str.normalize() {
+  kitbash.str.normalise "$@"
+}
+
 ##
 
 bb.core.casefold() {
-  local raw="$1"
-  local locale
+  local raw locale
+  raw="$1"
   # See if we can find a UTF-8 locale, in order to ensure a broader range of
   #   characters that can or should be folded down.
   # Doesn't handle the full range of unicode characters that *might* need to
@@ -207,13 +229,28 @@ bb.core.casefold() {
   #   management too, right?
   # Finally, fall into the basic C locale if we can't find a UTF-8 locale to
   #   use.
-  for loc in C.UTF-8 C.utf8 en_US.utf8 en_US.UTF-8 UTF-8 C; do
-    if locale -a 2>/dev/null | grep -qi "^${loc}$"; then
-      locale="$loc"
-      break
-    fi
-  done
-  
+  if [[ -z "$__STR_CASEFOLD_LOCALE" ]]; then
+    # Try to default to the standard C locale
+    __STR_CASEFOLD_LOCALE="C"
+    local locales
+    # Performance optimization, only fetch locales once instead of fetching
+    # the whole list on every cycle through the loop.
+    locales="$(locale -a 2>/dev/null)"
+    # TODO: Generate OS-specific locales that get loaded in at runtime in
+    #   order to ensure that this particular locale set isn't the only 
+    #   one we try to use.
+    for loc in C.UTF-8 C.utf8 en_US.utf8 en_US.UTF-8 UTF-8 C; do
+      if grep -qi -x -- "$loc" <<<"$locales"; then
+        # Optimization, cache the locale once across the entire run of Kitbash
+        __STR_CASEFOLD_LOCALE="$loc"
+        break
+      fi
+    done
+  fi
+  locale="$__STR_CASEFOLD_LOCALE"
+  # Shelling out to awk for this is perhaps not ideal, but it does provide
+  # somewhat better syntax for folding all capital letters down to their 
+  # lowercase equivalents in our given locale.
   LC_ALL="$locale" awk 'BEGIN {
     str = ARGV[1];
     ARGV[1] = "";
@@ -222,7 +259,10 @@ bb.core.casefold() {
 }
 
 std.casefold() {
-  bb.core.casefold "$@"
+  bb.core.casefold "$*"
+}
+str.casefold() {
+  bb.core.casefold "$*"
 }
 
 ## Load a file, relative to the callsite

--- a/helpers/variables.sh
+++ b/helpers/variables.sh
@@ -10,8 +10,9 @@ declare -ag __KITBASH_VAR_RESOLVERS
 declare -ag __KITBASH_VAR_SECRET_RESOLVERS
 
 declare -ag __KITBASH_VAR_RESOLVERS_INIT
+declare -ag __KITBASH_SECRET_RESOLVERS_INIT
 
-declare -Ag __KITBASH_VAR_CACHE
+
 declare -g __KITBASH_LOAD_VARIABLES
 __KITBASH_LOAD_VARIABLES=0
 
@@ -31,35 +32,31 @@ info.var() {
     return 1
   }
   
-  # This is still wrong.
-  # TODO: Fix this, since it'll cause weirdness later on with variable providers that aren't "load everything" style.
-  
   log.debug "Searching for variable: '$name'"
-  if (( __KITBASH_LOAD_VARIABLES == 0 )); then
-    log.debug "kitbash loading variables..."
-    value=$(kitbash.vars.load "$name")
-    [[ -n "$value" ]] && {
-      printf '%s' "$value"
-      __KITBASH_LOAD_VARIABLES=1
+  
+  # Assume that all resolvers will handle their own caching, since trying to
+  #   overload logic here to add a cache is silly.
+  local resolver exit_code
+  for resolver in "${__KITBASH_VAR_RESOLVERS[@]}"; do
+    value=$("$resolver" "$name")
+    exit_code="$?" # Immediately capture the exit code
+    # TODO: Define error codes and use case logic to handle them here or some
+    #   sort of exception handler system eventually.
+    # ... This project is growing its own OO-style environment. Oops.
+    if [[ -n "$value" ]]; then
+      printf '%s\n' "$value"
       return 0
-    }
-  fi
-
-  # 1. Cached value
-  if [[ -n "${__KITBASH_VAR_CACHE["$name"]+x}" ]]; then
-    log.debug "info.var: cache hit for '$name'"
-    log.debug "Value: ${__KITBASH_VAR_CACHE["$name"]}"
-    printf '%s' "${__KITBASH_VAR_CACHE["$name"]}"
-    return 0
-  fi
+    fi
+  done
+  
   # 3. Default / error
   if [[ -n "$default" ]]; then
     log.debug "info.var: returning default for '$name'"
-    printf '%s' "$default"
+    printf '%s\n' "$default"
     return 0
   fi
 
-  log.error "Variable '$name' not set and no default provided"
+  log.error "Variable '$name' not found and no default provided."
   return 1
 }
 
@@ -185,6 +182,24 @@ kitbash.vars.init.register() {
     append|*)
       log.debug "Appending '${function}'"
       types.set.append __KITBASH_VAR_RESOLVERS_INIT "$function"
+      ;;
+  esac
+}
+
+kitbash.secrets.init.register() {
+  local function
+  function="$1"
+  log.debug "Registering init: '${function}'"
+  local mode
+  mode="${2:-prepend}"
+  case "$mode" in
+    prepend)
+      log.debug "Prepending '${function}'"
+      types.set.prepend __KITBASH_SECRET_RESOLVERS_INIT "$function"
+      ;;
+    append|*)
+      log.debug "Appending '${function}'"
+      types.set.append __KITBASH_SECRET_RESOLVERS_INIT "$function"
       ;;
   esac
 }

--- a/helpers/variables/files.sh
+++ b/helpers/variables/files.sh
@@ -1,9 +1,13 @@
 # Variables file loader
 
+declare -Ag __KITBASH_VAR_FILE_CACHE
+declare -Ag __KITBASH_SECRET_FILE_CACHE
+
 # Load from general variables files
 kitbash.vars.register_resolver kitbash.vars.files.lookup append
 # The variables init, since it assumes that it'll be caching.
 kitbash.vars.init.register kitbash.vars.files.init
+kitbash.secrets.init.register kitbash.vars.files.init
 # Load from secrets variables files
 kitbash.vars.secrets.register_resolver kitbash.vars.files.secret append
 
@@ -11,16 +15,30 @@ kitbash.vars.secrets.register_resolver kitbash.vars.files.secret append
 # declare -g __KITBASH_LOAD_FILES
 # __KITBASH_LOAD_FILES=1
 
+# Load files on init, so we're not doing silly searching on each run through.
+# Caches directly, since that's more sensible than having a global cache, and
+#   we can more sensibly use the resolver chain to ensure that the right value
+#   is getting returned.
+# This does result in some wasted work, but, enh.
 kitbash.vars.files.init() {
-  local fn line key val directory
+  local fn
   
-  for fn in $(kitbash.vars.files.list KITBASH_VARIABLE_PATHS); do
-    log.debug "Checking file '$fn'"
-    for line in $(kitbash.vars.files.read "$fn"); do
-      log.debug "Caching line $line"
-      kitbash.vars.files.cache "$line"
-    done
-  done
+  # IFS= sets IFS to \0 instead of \n, which lets more complex values through
+  # if need be.
+  while IFS= read -r -d '' fn; do
+    log.debug "reading $fn into variable cache"
+    kitbash.vars.files.read_into "$fn" "__KITBASH_VAR_FILE_CACHE"
+  done < <(kitbash.vars.files.list0 KITBASH_VARIABLE_PATHS)
+}
+
+kitbash.secrets.files.init() {
+  local fn
+  log.debug "Initializing secrets cache"
+  log.debug "Using ${KITBASH_SECRET_PATHS[@]}"
+  while IFS= read -r -d '' fn; do
+    log.debug "reading $fn into secret cache"
+    kitbash.vars.files.read_into "$fn" "__KITBASH_SECRET_FILE_CACHE"
+  done < <(kitbash.vars.files.list0 KITBASH_SECRET_PATHS)
 }
 
 # kitbash.vars.files.general
@@ -33,180 +51,263 @@ kitbash.vars.files.lookup() {
   name="$1"
   
   log.debug "Checking '$name'"
-  log.debug "${__KITBASH_VAR_CACHE["$name"]}" 
-  if [[ -v __KITBASH_VAR_CACHE["$name"] ]]; then
-    echo "${__KITBASH_VAR_CACHE["$name"]}"
+  log.debug "${__KITBASH_VAR_FILE_CACHE["$name"]}"
+  # Requires Bash >=5.2
+  if [[ -v __KITBASH_VAR_FILE_CACHE["$name"] ]]; then
+    printf '%s\n' "${__KITBASH_VAR_FILE_CACHE["$name"]}"
     return
   fi
   return 1
 }
 
-kitbash.vars.files.list() {
+kitbash.vars.files.list0() {
   local -n paths
   paths="$1"
+  log.debug "Reading from $1"
   local model directory models_d fn suffix
   local -a search_paths
+  
+  local -a model_files_find_query
+  local -a glob_find_query
+  
+  # Generate the list of possible model filenames once.
+  # for model in "${__KITBASH_MODEL_TREE_STACK[@]}"; do
+  #   for suffix in "${KITBASH_VARIABLE_SUFFIXES[@]}"; do
+  #     model_files_find_query+=(-name "$model.$suffix" -or)
+  #   done
+  #   # Strip the last -o since it'll error otherwise.
+  #   unset 'model_find_query[-1]'
+  # done
+  
+  for suffix in "${KITBASH_VARIABLE_SUFFIXES[@]}"; do
+    glob_find_query+=(-name "*.$suffix" -o)
+  done
+  (( "${#glob_find_query[@]}" == 0 )) || {
+    # Strip the last "-or" since it's an error.
+    unset glob_find_query[-1]
+  }
+  log.debug "Glob query: '${glob_find_query[@]}'"
+  
+  # Generate the model files list first
+  kitbash.vars.files.model.list0
+  
+  # Recombine discovered search paths with original incoming paths, with the
+  #   understanding that any already-defined items will be skipped by the
+  #   parser due to already being cached.
+  log.debug "Finding generic variable files"
+  search_paths=("${search_paths[@]}" "${paths[@]}")
+  unset directory
+  for directory in "${search_paths[@]}"; do
+    log.debug "Searching path $directory"
+    find -L "$directory" -maxdepth 1 -type f \( "${glob_find_query[@]}" \) -print0 | sort -znr
+  done
+}
+
+kitbash.vars.files.model.list0() {
+  local model suffix
+  declare -a model_files_find_query
+  declare -a glob_find_query
+  
+  # Generate the list of valid suffixes to search for in the 
+  #  models.d/modelname directories
+  
+  for suffix in "${KITBASH_VARIABLE_SUFFIXES[@]}"; do
+    glob_find_query+=(-name "*.$suffix" -o)
+  done
+  (( "${#glob_find_query[@]}" == 0 )) || {
+    # Strip the last "-or" since it's an error.
+    unset glob_find_query[-1]
+  }
+  
+  # Generate a list of filenames ala model.sh, model.bash, etc.
+  
+  log.debug "Model stack: '${__KITBASH_MODEL_TREE_STACK[@]}'"
+  
+  [[ -n "$KITBASH_CURRENT_MODEL" ]] || {
+    log.warn "No model set."
+    return 0
+  }
+  
+  (( "${#__KITBASH_MODEL_TREE_STACK[@]}" == 0 )) && {
+    # There's no models to check over, so we can just return.
+    log.warn "No model stack established."
+    return 0
+  }
+  
+  for model in "${__KITBASH_MODEL_TREE_STACK[@]}"; do
+    for suffix in "${KITBASH_VARIABLE_SUFFIXES[@]}"; do
+      model_files_find_query+=(-name "$model.$suffix" -o)
+    done
+  done
+  # Strip the last -o since it'll error otherwise.
+  (( "${#model_files_find_query[@]}" >= 1 )) && {
+    unset model_files_find_query[-1]
+  }
+  log.debug "query: '${model_files_find_query[@]}'"
+  
+  # Generates the list of search paths
+  # ${paths[@]} exists in scope because it's from our caller's scope.
+  # This is obviously really brittle and shouldn't be done.
   for directory in "${paths[@]}"; do
     models_d="$directory"/"$KITBASH_MODELS_DIRECTORY_NAME"
-    log.debug "Using models directory $models_d"
+    log.debug "Checking models directory $models_d"
+    
+    [[ -e "$models_d" ]] || {
+      log.debug "$models_d does not exist."
+      continue
+    }
     
     # The first model loaded is the model we're examining, always.
     # Then it proceeds down the tree to subsequent models, to see if they have
     # defined any variable files, to allow for models to provide a default
-    # definition for any given variable.
+    # definition for any given variable.    
     for model in "${__KITBASH_MODEL_TREE_STACK[@]}"; do
       log.debug "Adding '$model' to search path"
+      
+      # This will be like model.d/model_name, where we want to grab *.sh, *.bash, etc.
       model_path="$models_d/$model"
+      
       # If a current model is defined, we want to scope our variable lookups
       # to that.
       # That means we'll either load up a file with the model's name AND/OR
       # all the files in the directory with the model's name.
       
       if [[ -e "$model_path" && -d "$model_path" ]]; then
+        log.debug "Adding to search path: '$model_path'"
         search_paths+=("$model_path")
       fi
       # Now, look in the models.d directory for any files named for the model
       # we're looking at.
-      for suffix in "${KITBASH_VARIABLE_SUFFIXES[@]}"; do
-        log.debug "Checking for suffixed model files matching '$model'"
-        fn="$models_d"/"$model"."$suffix"
-        log.debug "Checking '$fn'"
-        if [[ -e "$fn" ]]; then
-          log.debug "found model file: '$fn'"
-          echo "$fn"
-        fi
-      done
     done
-  done
-  # Recombine discovered search paths with original incoming paths
-  search_paths=("${search_paths[@]}" "${paths[@]}")
-  unset directory
-  for directory in "${search_paths[@]}"; do
-    log.debug "Searching path $directory"
-    kitbash.vars.files.list_directory "$directory"
+    # The literal models files, if any, come afterwards.
+    # Uses \(\) to group all the name OR statements together.
+    # This searches through all the explicitly-named model filenames *first*,
+    #   before moving on to the model-specific directories.
+    # ... Though maybe they should take priority...?
+    # ... should figure that out.
+    log.debug "Finding model files in $models_d"
+    find -L "$models_d" -maxdepth 1 -type f \( "${model_files_find_query[@]}" \) -print0
   done
 }
 
 # kitbash.vars.files.secret
 # Returns a secret based on the provided key
-# Does not cache. Parses all secrets files on each invocation.
-# This is intentional, to allow for (for example) a FIFO buffer connected to
-# a logging script to log when secrets are read.
+# Uses a cache, since re-reading secrets for every invocation is quite
+#   wasteful, even on modern machines.
 kitbash.vars.files.secret() {
   local name
   name="$1"
-  local fn line key val directory
-  log.debug "Searching for key: '$name'"
-  if [[ "${KITBASH_SECRET_PATHS[@]}" == "0" ]]; then
-    log.error "No secret paths defined!"
-    kitbash.fail
+  log.debug "Searching for secret: '$name'"
+  
+  if [[ -v __KITBASH_SECRET_FILE_CACHE["$name"] ]]; then
+    printf '%s\n' "${__KITBASH_SECRET_FILE_CACHE["$name"]}"
+    return
   fi
-  for fn in $(kitbash.vars.files.list KITBASH_SECRETS_PATHS); do
-    log.debug "Searching in '$fn'"
-    for line in $(kitbash.vars.files.read "$fn"); do
-      # I wish there was a better way to do this.
-      if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-        key="${BASH_REMATCH[1]}"
-        val="${BASH_REMATCH[2]}"
-        if [[ "$key" == "$name" ]]; then
-          printf '%s' "$val"
-          return 0
-        fi
-      fi
-    done
-  done
   emit error "No such secret '$name'"
   return 1
 }
 
-kitbash.vars.files.cache() {
-  local line key val
-  line="$1"
-  
-  line="${line%%#*}"
-  # Use the built-in text normalizer to strip leading and trailing line
-  # whitespace
-  line=$(normalize "$line")
-  # Is the line empty?
-  [[ -z "$line" ]] && return 1
-  # Match KEY=value
-  if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-    key="${BASH_REMATCH[1]}"
-    val="${BASH_REMATCH[2]}"
-    log.debug "Found key: $key"
-    # Only load into cache if it's not already been found.
-    # If it has, we can ignore it.
-    if ! [[ -v __KITBASH_VAR_CACHE["$key"] ]]; then
-      log.debug "Adding to cache: '$key'='$val"
-      __KITBASH_VAR_CACHE["$key"]="$val"
-    fi
-  fi
-}
-
-kitbash.vars.files.read() {
-  local fn
+# Read in and parse k=v files into a provided hash.
+# Allows for easy re-use of k=v reader functionality between normal file and
+#   secret file formats.
+# 
+kitbash.vars.files.read_into() {
+  local fn key value
+  local -n target
+  log.debug "Received target '$2'"
   fn="$1"
+  target="$2"
+  
   [[ -e "$fn" && -f "$fn" ]] || {
     log.warn "Not a file: '$fn'"
     return 1
   }
-  while IFS='\n' read -r line || [[ -n "$line" ]]; do
-    # We don't need comments
-    log.debug "Loaded initial line: '$line'"
-    line="${line%%#*}"
-    # Use the built-in text normalizer to strip leading and trailing line
-    # whitespace
-    line=$(normalize "$line")
-    # Is the line empty?
-    [[ -z "$line" ]] && continue
+  types.hash.exists "$2" || {
+    log.error "Target $2 not declared."
+    return "$?"
+  }
   
-    # Match KEY=value
-    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
-      printf '%s\n' "$line"
+  while read -r line || [[ -n "$line" ]]; do
+    # Reset key and value.
+    key=""
+    val=""
+    log.debug "Loaded line: '$line'"
+    
+    if __kitbash_parse_line "$line"; then
+      log.debug "Line parsed"
+      # If the key does not exist, then set it.
+      # If it does exist, then we don't want to overwrite it.
+      [[ ! -v target["$KITBASH_KV_PARSE_KEY"] ]] && {
+        log.debug "Setting $KITBASH_KV_PARSE_KEY in target $2"
+        target["${KITBASH_KV_PARSE_KEY}"]="$KITBASH_KV_PARSE_VAL"
+      }
     else
-      log.error "Bad line in $fn: $line"
+      # Otherwise, we can just continue onwards.
+      continue
     fi
   done < "$fn"
+  log.debug "Finished reading $fn"
 }
 
-kitbash.vars.files.load_directory() {
-  local fn directory
-  directory="$1"
-  if ! [[ -e "$directory" && -d "$directory" ]]; then
-    log.warn "No such directory: '$directory'"
-    return 0
+__kitbash_parse_line() {
+  local line key value
+  declare -g KITBASH_KV_PARSE_KEY
+  declare -g KITBASH_KV_PARSE_VAL
+  line="$1"
+  
+  log.debug "called with line: '$line'"
+  
+  # First, trim leading whitespace
+  line="${line#"${line%%[![:space:]]*}"}"
+  
+  # Second, check if the first character is a comment
+  # If we start with a comment, skip line.
+  if [[ "${line::1}" == "#" ]]; then
+    # Just return, since comments are skipped
+    return
   fi
-  # Uses reverse order so that files can be dropped in via orchestrator or
-  # other system with large prefixes and get selected first.
-  for fn in $(find  -L "$directory" -maxdepth 1 -type f | sort -nr); do
-    log.debug "Checking file: '$fn'"
-    # If the filename suffix is in our global kitbash variable name suffixes,
-    # then we attempt to read it.
-    if types.array.contains KITBASH_VARIABLE_SUFFIXES "${fn##*.}"; then
-      log.debug "File suffix matches allowed suffixes"
-      kitbash.vars.files.read "$fn"
-    fi
-  done
-}
-
-kitbash.vars.files.list_directory() {
-  local fn directory
-  directory="$1"
-  log.debug "Searching $directory..."
-  if ! [[ -e "$directory" && -d "$directory" ]]; then
-    log.debug "No such directory: '$directory'"
-    return 0
+  
+  # Trim trailing whitespace as well, just to normalise things up
+  line="${line%"${line##*[![:space:]]}"}"
+  
+  # If there's nothing left, we can skip the line
+  [[ -z "$line" ]] && return 0
+  
+  # We have three types of valid k=v styles:
+  # foo=bar_baz
+  # foo="bar baz"
+  # foo='bar baz'
+  # So, we want to regex test for all of them
+  
+  regex_key="[A-Za-z_][A-Za-z0-9_]*"
+  
+  regex_unquoted="^($regex_key)=([A-Za-z0-9_#%^*@]+)(\s#.*)*$"
+  # regex_doublequoted="^([A-Za-z_][A-Za-z0-9_]*)=\"([^\"]*)\"$"
+  regex_doublequoted='^([A-Za-z_][A-Za-z0-9_]*)="(([^"\\]|\\.)*)"$'
+  regex_singlequoted="^([A-Za-z_][A-Za-z0-9_]*)='(([^'\\\\]|\\\\.)*)'$"
+  
+  if [[ "$line" =~ $regex_unquoted ]]; then
+    log.debug "Found unquoted line $line"
+    # Captures the possible comment at the end
+    key="${BASH_REMATCH[1]}"
+    val="${BASH_REMATCH[2]}"
+  elif [[ "$line" =~ $regex_doublequoted || "$line" =~ $regex_singlequoted ]]; then
+    # This implicitly drops trailing comments
+    key="${BASH_REMATCH[1]}"
+    val="${BASH_REMATCH[2]}"
+    # Strip escapes
+    val="${val//\\\"/\"}"
+    val="${val//\\\'/\'}"
+    val="${val//\\\\/\\}"
+  else
+    # If we didn't match any of our styles, we abort here.
+    log.warn "Line did not match k=v parse rules"
+    log.debug "${BASH_REMATCH[0]}"
+    log.debug "$line"
+    return 1
   fi
-  # Uses reverse order so that files can be dropped in via orchestrator or
-  # other system with large prefixes and get selected first.
-  log.debug "Finding files"
-  for fn in $(find -L "$directory" -maxdepth 1 -type f | sort -nr); do
-    log.debug "Checking file: '$fn'"
-    # If the filename suffix is in our global kitbash variable name suffixes,
-    # then we attempt to read it.
-    if types.array.contains KITBASH_VARIABLE_SUFFIXES "${fn##*.}"; then
-      log.debug "File suffix matches allowed suffixes"
-      echo "$fn"
-    fi
-  done
+  
+  # finally, assign to the globals for return to the caller.
+  KITBASH_KV_PARSE_KEY="$key"
+  KITBASH_KV_PARSE_VAL="$val"
 }

--- a/tests/bats/helpers/secrets.bats
+++ b/tests/bats/helpers/secrets.bats
@@ -3,6 +3,8 @@ load "../../bats_helpers/bats-support/load"
 load "../../bats_helpers/bats-assert/load"
 # load "../../helpers/system_info.sh"
 
+declare -Ag __KITBASH_SECRET_FILE_CACHE
+
 setup() {
   DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
   
@@ -15,6 +17,12 @@ setup() {
   . "${DIR}/../../../helpers/02-system_info.sh"
   . "${DIR}/../../../helpers/variables.sh"
   export KITBASH_TEST_CALLER="$BATS_TEST_FILENAME"
+  unset KITBASH_SECRET_PATHS
+  # __KITBASH_MODEL_TREE_STACK=(modelname)
+  # KITBASH_LOG_LEVEL=0
+  # # Should? overwrite the values.
+  # declare -Ag __KITBASH_VAR_FILE_CACHE
+  # declare -Ag __KITBASH_SECRET_FILE_CACHE
 }
 
 teardown() {
@@ -25,14 +33,17 @@ teardown() {
 }
 
 @test "info.var.secret returns present secret" {
-  # KITBASH_LOG_LEVEL=0
-  KITBASH_SECRETS_PATHS=("$DIR/variables/basic")
+  
+  # Need to re-run init as we're 
+  KITBASH_SECRET_PATHS=("$DIR/variables/basic")
+  kitbash.secrets.files.init
   run info.var.secret "GREETING"
   assert_output "hello"
 }
 
 @test "info.var.secret fails on missing" {
-  KITBASH_SECRETS_PATHS=("$DIR/variables/basic")
+  KITBASH_SECRET_PATHS=("$DIR/variables/basic")
+  kitbash.secrets.files.init
   run info.var.secret "MISSING"
   assert_failure 1
 }
@@ -40,10 +51,13 @@ teardown() {
 # bats test_tags=override
 @test "info.var.secret model script file overrides" {
   # KITBASH_LOG_LEVEL=0
-  KITBASH_SECRETS_PATHS=("$DIR/variables/basic" "$DIR/variables/with_model_script")
+  KITBASH_SECRET_PATHS=("$DIR/variables/basic" "$DIR/variables/with_model_script")
   KITBASH_MODEL_INHERITANCE=(modelname)
   __KITBASH_MODEL_TREE_STACK=(modelname)
   KITBASH_CURRENT_MODEL=modelname
+  # Re-run secrets init, since it runs over the secrets paths at startup
+  kitbash.secrets.files.init
+  
   run info.var.secret "GREETING"
   assert_output "modelname"
 }

--- a/tests/bats/helpers/variable_file_parser.bats
+++ b/tests/bats/helpers/variable_file_parser.bats
@@ -1,0 +1,91 @@
+DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+load "../../bats_helpers/bats-support/load"
+load "../../bats_helpers/bats-assert/load"
+# load "../../helpers/system_info.sh"
+
+setup() {
+  DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+  
+  # Load Babashka itself
+  . "${DIR}/../../../bin/babashka"
+  # load the Kitbash libraries we're testing.
+  . "${DIR}/../../../helpers/00-color.sh"
+  . "${DIR}/../../../helpers/00-log.sh"
+  . "${DIR}/../../../helpers/01-core.sh"
+  . "${DIR}/../../../helpers/02-system_info.sh"
+  . "${DIR}/../../../helpers/variables.sh"
+  export KITBASH_TEST_CALLER="$BATS_TEST_FILENAME"
+  # Set log level to debug
+  KITBASH_LOG_LEVEL=0
+  # declare -g KITBASH_KV_PARSE_KEY
+  # declare -g KITBASH_KV_PARSE_VAL
+}
+
+teardown() {
+  # Clear the results we got back
+  unset KITBASH_KV_PARSE_KEY
+  unset KITBASH_KV_PARSE_VAL
+}
+
+@test "__kitbash_parse_line skips comment lines" {
+  __kitbash_parse_line "# foo=\"bar\""
+  # assert_success
+  refute [ -n "$KITBASH_KV_PARSE_KEY" ]
+  refute [ -n "$KITBASH_KV_PARSE_VAL" ]
+}
+
+@test "__kitbash_parse_line fails on non-kv lines" {
+  run __kitbash_parse_line "foobar"
+  assert_failure
+}
+
+@test "__kitbash_parse_line captures unquoted lines" {
+  __kitbash_parse_line "foo=bar"
+  
+  assert_equal "$KITBASH_KV_PARSE_KEY" "foo"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "bar"
+}
+
+@test "__kitbash_parse_line unquoted lines allow #" {
+  __kitbash_parse_line "foo=bar#baz"
+  
+  assert_equal "$KITBASH_KV_PARSE_KEY" "foo"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "bar#baz"
+}
+
+@test "__kitbash_parse_line captures quoted values" {
+  __kitbash_parse_line 'foo="bar"'
+  # assert_success
+  assert_equal "$KITBASH_KV_PARSE_KEY" "foo"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "bar"
+  
+  __kitbash_parse_line "baz='foobaz'"
+  assert_equal "$KITBASH_KV_PARSE_KEY" "baz"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "foobaz"
+}
+
+@test "__kitbash_parse_line allows internal escaped doublequotes" {
+  __kitbash_parse_line 'foo="bar \"baz\""'
+  # assert_success
+  assert_equal "$KITBASH_KV_PARSE_KEY" "foo"
+  assert_equal "$KITBASH_KV_PARSE_VAL" 'bar "baz"'
+}
+
+@test "__kitbash_parse_line allows internal escaped single quotes" {
+
+  __kitbash_parse_line "baz='foo \'baz\''"
+  assert_equal "$KITBASH_KV_PARSE_KEY" "baz"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "foo 'baz'"
+}
+
+
+@test "__parse_line parses LOG_LEVEL=warn" {
+  __kitbash_parse_line "LOG_LEVEL=warn"
+  assert_equal "$KITBASH_KV_PARSE_KEY" "LOG_LEVEL"
+  assert_equal "$KITBASH_KV_PARSE_VAL" "warn"
+}
+
+@test "__parse_line aborts on unbalanced quote" {
+  run __kitbash_parse_line "foo='bar"
+  assert_failure
+}

--- a/tests/bats/helpers/variables.bats
+++ b/tests/bats/helpers/variables.bats
@@ -3,38 +3,50 @@ load "../../bats_helpers/bats-support/load"
 load "../../bats_helpers/bats-assert/load"
 # load "../../helpers/system_info.sh"
 
+declare -Ag __KITBASH_VAR_FILE_CACHE
+
 setup() {
   DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
   
   # Load Babashka itself
   . "${DIR}/../../../bin/babashka"
-  # load the bats helpers
+  # load the Kitbash libraries we're testing.
   . "${DIR}/../../../helpers/00-color.sh"
   . "${DIR}/../../../helpers/00-log.sh"
   . "${DIR}/../../../helpers/01-core.sh"
   . "${DIR}/../../../helpers/02-system_info.sh"
   . "${DIR}/../../../helpers/variables.sh"
   export KITBASH_TEST_CALLER="$BATS_TEST_FILENAME"
+  # unset KITBASH_VARIABLE_PATHS
 }
 
 teardown() {
   unset KITBASH_VARIABLE_PATHS
   unset KITBASH_CURRENT_MODEL
-  unset __KITBASH_VAR_CACHE
-  __KITBASH_LOAD_VARIABLES=0
+  unset __KITBASH_VAR_FILE_CACHE
+  
   unset KITBASH_MODEL_INHERITANCE
   unset __KITBASH_MODEL_TREE_STACK
 }
 
+##
+## Test the kitbash.vars.files.lookup code paths specifically, to test the
+## override functionality.
+## Files now doesn't bother trying to parse files before looking in the cache;
+## it now loads everything into a dict and goes from there automatically.
+##
+
 @test "kitbash.vars.files.lookup caches basic files" {
   # KITBASH_LOG_LEVEL=0
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  kitbash.vars.files.init
   run kitbash.vars.files.lookup "GREETING"
   assert_output "hello"
 }
 
 @test "kitbash.vars.files.lookup uses reverse lexical sort for files" {
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  kitbash.vars.files.init
   run kitbash.vars.files.lookup "DEPARTURE"
   assert_output "departed"
 }
@@ -44,6 +56,7 @@ teardown() {
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic" "$DIR/variables/with_model_script")
   __KITBASH_MODEL_TREE_STACK=(modelname)
   KITBASH_CURRENT_MODEL=modelname
+  kitbash.vars.files.init
   run kitbash.vars.files.lookup "GREETING"
   assert_output "modelname"
 }
@@ -54,19 +67,35 @@ teardown() {
   __KITBASH_MODEL_TREE_STACK=(modelname)
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic" "$DIR/variables/with_model_dir")
   KITBASH_CURRENT_MODEL=modelname
+  kitbash.vars.files.init
   run kitbash.vars.files.lookup "GREETING"
   assert_output "modelname_directory"
 }
 
+@test "kitbash.vars.files.lookup returns warn for trailing 'n'" {
+  KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  # KITBASH_LOG_LEVEL=0
+  kitbash.vars.files.init
+  run kitbash.vars.files.lookup "TRAILING_N"
+  assert_output warn
+}
+
+#
+# Test the info.var path specifically
+#
+
+
 @test "info.var returns present value" {
   # KITBASH_LOG_LEVEL=0
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  kitbash.vars.files.init
   run info.var "GREETING"
   assert_output "hello"
 }
 
 @test "info.var fails on missing" {
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  kitbash.vars.files.init
   run info.var "MISSING"
   assert_failure 1
 }
@@ -76,6 +105,22 @@ teardown() {
   KITBASH_VARIABLE_PATHS=("$DIR/variables/basic" "$DIR/variables/with_model_script")
   __KITBASH_MODEL_TREE_STACK=(modelname)
   KITBASH_CURRENT_MODEL=modelname
+  kitbash.vars.files.init
   run info.var "GREETING"
   assert_output "modelname"
 }
+
+@test "info.var returns quoted value" {
+  KITBASH_VARIABLE_PATHS=("$DIR/variables/quoted")
+  kitbash.vars.files.init
+  run info.var "GREETING"
+  assert_output "asd"
+}
+
+@test "info.var returns warn for trailing 'n'" {
+  KITBASH_VARIABLE_PATHS=("$DIR/variables/basic")
+  kitbash.vars.files.init
+  run info.var "TRAILING_N"
+  assert_output warn
+}
+

--- a/tests/bats/helpers/variables/basic/00-basic.sh
+++ b/tests/bats/helpers/variables/basic/00-basic.sh
@@ -1,2 +1,3 @@
 GREETING=hello
+TRAILING_N=warn
 DEPARTURE=gone

--- a/tests/bats/helpers/variables/combined_model_dir_script/models.d/modelname.sh
+++ b/tests/bats/helpers/variables/combined_model_dir_script/models.d/modelname.sh
@@ -1,0 +1,1 @@
+GREETING=modelname

--- a/tests/bats/helpers/variables/combined_model_dir_script/models.d/modelname/general.sh
+++ b/tests/bats/helpers/variables/combined_model_dir_script/models.d/modelname/general.sh
@@ -1,0 +1,1 @@
+GREETING=modelname directory

--- a/tests/bats/helpers/variables/quoted/quoted.sh
+++ b/tests/bats/helpers/variables/quoted/quoted.sh
@@ -1,0 +1,1 @@
+GREETING="asd"

--- a/tests/bats/helpers/variables/with_comments/comments.sh
+++ b/tests/bats/helpers/variables/with_comments/comments.sh
@@ -1,0 +1,2 @@
+WITH_QUOTES="quoted" # with comment
+WITHOUT_QUOTES=unquoted # comment


### PR DESCRIPTION
- Quoted values parse correctly.
- Trailing `n` variables are parsed correctly.
- Trailing comments are correctly stripped.
- `#` in the middle of a bare string is handled correctly. Variable files are now read at startup, as are variable secret files, and cached internally. Update tests.